### PR TITLE
Curation Exception

### DIFF
--- a/plugins/transaction/curation/src/main/java/com/googlecode/fascinator/redbox/plugins/curation/redbox/CurationManager.java
+++ b/plugins/transaction/curation/src/main/java/com/googlecode/fascinator/redbox/plugins/curation/redbox/CurationManager.java
@@ -491,16 +491,14 @@ public class CurationManager extends GenericTransactionManager {
 
         // Mint records we are less strict about and happy
         //  to allow multiple links in differing fields.
-        String newId = (String) newRelation.get("identifier");
-        String newField = (String) newRelation.get("field");
         for (Object relation : relations) {
             JsonObject json = (JsonObject) relation;
 
             if (json.containsKey("identifier")) {
                 String knownId = (String) json.get("identifier");
                 String knownField = (String) json.get("field");
-                    //String newId = (String) newRelation.get("identifier");
-                    //String newField = (String) newRelation.get("field");
+                String newId = (String) newRelation.get("identifier");
+                String newField = (String) newRelation.get("field");
                 // And does the ID match?
                 if (knownId.equals(newId) && knownField.equals(newField)) {
                     return true;
@@ -609,6 +607,7 @@ public class CurationManager extends GenericTransactionManager {
         //***
         // What should happen per task if we have already been curated?
         if (curated) {
+
             // Happy ending
             if (task.equals("curation-response")) {
                 log.info("Confirmation of curated object '{}'.", oid);


### PR DESCRIPTION
During curation the following exception was set in the transactionManager.log (see below)

The problem is caused because the OID is not a hash value. 
The code changes in this pull request ensure that in checkChildren(), idToOid() is called to convert the identifier to an OID. This processing occurs during the creation of the task: curation-request.

If more detail is required, please contact me.

Thanks,
              Jay van Schyndel
              jay.vanschyndel@jcu.edu.au

2012-11-17 13:36:13,349 transactionManager DEBUG  CurationManager  
{
    "task": "curation-request",
    "oid": "jcu.edu.au/tdh/collection/Southern Cassowary - Casuaris casuaris/occurrences",
    "relationships": [
        {
            "identifier": "jcu.edu.au/tdh/collection/Southern Cassowary - Casuaris casuaris/occurrences",
            "curatedPid": "jcu.edu.au/tdh/collection/Southern Cassowary - Casuaris casuaris/occurrences",
            "broker": "tcp://localhost:9101",
            "isCurated": true,
            "relationship": "hasDerivedCollection",
            "oid": "aadc26460168919bdb0b6f0a3d6882af"
        }
    ],
    "respond": {
        "broker": "tcp://localhost:9101",
        "oid": "aadc26460168919bdb0b6f0a3d6882af",
        "task": "curation-pending"
    }
}
2012-11-17 13:36:13,350 transactionManager ERROR  CurationManager      Error accessing object 'jcu.edu.au/tdh/collection/Southern Cassowary - Casuaris casuaris/occurrences' in storage: 
com.googlecode.fascinator.api.storage.StorageException: oID 'jcu.edu.au/tdh/collection/Southern Cassowary - Casuaris casuaris/occurrences' doesn't exist in storage.
    at com.googlecode.fascinator.storage.filesystem.FileSystemStorage.getObject(FileSystemStorage.java:206) ~[plugin-storage-filesystem-1.1.2.jar:na]
    at com.googlecode.fascinator.redbox.plugins.curation.redbox.CurationManager.getConfigFromStorage(CurationManager.java:1701) [plugin-transaction-curation-redbox-1.5.2.2.jar:na]
    at com.googlecode.fascinator.redbox.plugins.curation.redbox.CurationManager.curation(CurationManager.java:537) [plugin-transaction-curation-redbox-1.5.2.2.jar:na]
    at com.googlecode.fascinator.redbox.plugins.curation.redbox.CurationManager.parseMessage(CurationManager.java:1412) [plugin-transaction-curation-redbox-1.5.2.2.jar:na]
    at com.googlecode.fascinator.common.transaction.GenericTransactionManager.parseMessage(GenericTransactionManager.java:172) [fascinator-common-1.1.2.jar:na]
    at com.googlecode.fascinator.messaging.TransactionManagerQueueConsumer.onMessage(TransactionManagerQueueConsumer.java:382) [fascinator-core-1.1.2.jar:na]
    at org.apache.activemq.ActiveMQMessageConsumer.dispatch(ActiveMQMessageConsumer.java:1088) [activemq-all-5.3.0.jar:5.3.0]
    at org.apache.activemq.ActiveMQSessionExecutor.dispatch(ActiveMQSessionExecutor.java:127) [activemq-all-5.3.0.jar:5.3.0]
    at org.apache.activemq.ActiveMQSessionExecutor.iterate(ActiveMQSessionExecutor.java:197) [activemq-all-5.3.0.jar:5.3.0]
    at org.apache.activemq.thread.PooledTaskRunner.runTask(PooledTaskRunner.java:122) [activemq-all-5.3.0.jar:5.3.0]
    at org.apache.activemq.thread.PooledTaskRunner$1.run(PooledTaskRunner.java:43) [activemq-all-5.3.0.jar:5.3.0]
    at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886) [na:1.6.0_37]
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908) [na:1.6.0_37]
    at java.lang.Thread.run(Thread.java:680) [na:1.6.0_37] 
